### PR TITLE
Removing TODO section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,6 @@ Go to [http://localhost:9000](http://localhost:9000) in Chrome browser and click
 
 _If you're having a problem installing, you can create a bug or ask a question using the [BUILD Issue Tracker](https://github.com/SAP/BUILD/issues), contact contribute.build@sap.com or tweet our twitter account [buildwithbuild](https://twitter.com/buildwithbuild) and we will reach out to you._ 
 
-## TO DO 
-- [ ] Update package names
-- [X] Enable Prototype creation
-
 ## Licenses
 
 This project is licensed under the Apache Software License, v. 2 except as noted otherwise in the [License file](https://github.com/SAP/BUILD/blob/master/LICENSE.txt).


### PR DESCRIPTION
Removing the todo section in the readme as tasks are now being tracked
via issues
